### PR TITLE
Correct Slack community link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ You can  contribute to this repository with fixes and feature updates that do no
 
 ## Reporting an Issue / Reaching Us
 If you encounter any issues related with the app in this repository, you can raise an issue here.
-If you have any other issues or questions about Appcircle, you can contact us via our [contact form on Appcircle.io](https://appcircle.io/support) or join our Slack community at [slack.appcircle.io](slack.appcircle.io)
+If you have any other issues or questions about Appcircle, you can contact us via our [contact form on Appcircle.io](https://appcircle.io/support) or join our Slack community at [slack.appcircle.io](slack.appcircle.io)asdasdasd


### PR DESCRIPTION
Fixed a typo in the Slack community link.